### PR TITLE
 [Feat] 메인 화면 구성 및 Voice/Gaze 진입 버튼 기능 구현

### DIFF
--- a/client/src/components/CommonIcons.tsx
+++ b/client/src/components/CommonIcons.tsx
@@ -1,3 +1,5 @@
+import { useUIStore } from "../store/useUIStore";
+
 type Props = {
   isGazeActive: boolean;
   isVoiceActive: boolean;
@@ -5,10 +7,21 @@ type Props = {
 };
 
 export default function CommonIcons({ isGazeActive, isVoiceActive, isHelpActive }: Props) {
+  const { toggleGaze, toggleVoice, toggleHelp } = useUIStore();
+
   return (
     <>
       {/* Gaze Icon */}
-      <div style={{ position: "absolute", top: "16px", left: "16px" }}>
+      <div
+        style={{
+          position: "fixed",
+          top: "16px",
+          left: "16px",
+          zIndex: 1000,
+          cursor: "pointer",
+        }}
+        onClick={toggleGaze}
+      >
         <img
           src={`/icons/${isGazeActive ? "eye-on" : "eye-off"}.svg`}
           alt="Gaze Icon"
@@ -18,7 +31,16 @@ export default function CommonIcons({ isGazeActive, isVoiceActive, isHelpActive 
       </div>
 
       {/* Voice Icon */}
-      <div style={{ position: "absolute", top: "16px", right: "16px" }}>
+      <div
+        style={{
+          position: "fixed",
+          top: "16px",
+          right: "16px",
+          zIndex: 1000,
+          cursor: "pointer",
+        }}
+        onClick={toggleVoice}
+      >
         <img
           src={`/icons/${isVoiceActive ? "mic-on" : "mic-off"}.svg`}
           alt="Voice Icon"
@@ -28,7 +50,16 @@ export default function CommonIcons({ isGazeActive, isVoiceActive, isHelpActive 
       </div>
 
       {/* Help Icon */}
-      <div style={{ position: "absolute", bottom: "16px", right: "16px" }}>
+      <div
+        style={{
+          position: "fixed",
+          bottom: "16px",
+          right: "16px",
+          zIndex: 1000,
+          cursor: "pointer",
+        }}
+        onClick={toggleHelp}
+      >
         <img
           src={`/icons/${isHelpActive ? "help-on" : "help-off"}.svg`}
           alt="Help Icon"

--- a/client/src/sidepanel/pages/Choice.styles.tsx
+++ b/client/src/sidepanel/pages/Choice.styles.tsx
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  height: 100vh;
+  padding: 2rem;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const LogoWrapper = styled.div`
+  margin-bottom: 2rem;
+`;
+
+export const Text = styled.p`
+  font-size: 1.25rem;
+  font-family: var(--font-main);
+  font-style: italic;
+  font-weight: 200;
+  color: #212121;
+  margin-bottom: 2.5rem;
+`;
+
+export const ButtonGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  width: 100%;
+  max-width: 280px;
+`;

--- a/client/src/sidepanel/pages/Choice.tsx
+++ b/client/src/sidepanel/pages/Choice.tsx
@@ -1,12 +1,36 @@
+import * as S from './Choice.styles';
 import { useNavigate } from 'react-router-dom';
+import { useUIStore } from '../../store/useUIStore';
+import CommonButton from '../../components/CommonButton';
+import logo from '../../../public/icons/logo.png';
 
 export default function Choice() {
   const navigate = useNavigate();
+  const { isGazeActive, isVoiceActive } = useUIStore();
+
+  const handleStart = () => {
+    if (isGazeActive && isVoiceActive) {
+      navigate('/combined'); // 둘 다 켜졌을 때 가는 페이지 추가 예정
+    } else if (isGazeActive) {
+      navigate('/gaze');
+    } else if (isVoiceActive) {
+      navigate('/voice');
+    } else {
+      alert('Please activate at least one mode (Gaze or Voice).');
+    }
+  };
+
   return (
-    <div style={{ padding: 20 }}>
-      <h2>Customize your experience</h2>
-      <button onClick={() => navigate('/voice')}>Voice Control</button>
-      <button onClick={() => navigate('/gaze')}>Gaze Tracking</button>
-    </div>
+    <S.Container>
+      <S.LogoWrapper>
+        <img src={logo} alt="Logo" style={{ width: '120px' }} />
+      </S.LogoWrapper>
+
+      <S.Text>Customize your experience.</S.Text>
+
+      <S.ButtonGroup>
+        <CommonButton text="Start" onClick={handleStart} />
+      </S.ButtonGroup>
+    </S.Container>
   );
 }

--- a/client/src/sidepanel/pages/Home.styles.ts
+++ b/client/src/sidepanel/pages/Home.styles.ts
@@ -1,4 +1,15 @@
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
+
+const scaleIn = keyframes`
+  from {
+    opacity: 0;
+    transform: scale(0.6);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+`;
 
 export const Container = styled.div`
   position: relative;
@@ -18,6 +29,8 @@ export const LogoWrapper = styled.div`
 export const TextBox = styled.div`
   text-align: center;
   margin-top: 2rem;
+  min-height: 80px;
+  line-height: 1.5;
 `;
 
 export const Text = styled.p`
@@ -26,6 +39,17 @@ export const Text = styled.p`
   font-style: italic;
   font-weight: 200;
   margin: 0.25rem 0;
+`;
+
+export const TypingText = styled.p`
+  font-size: 1.2rem;
+  font-family: var(--font-main);
+  font-style: italic;
+  font-weight: 200;
+  margin: 0.25rem 0;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  opacity: 1;
 `;
 
 export const Gaze = styled.span`
@@ -39,5 +63,6 @@ export const Voice = styled.span`
 `;
 
 export const ButtonWrapper = styled.div`
-  margin-top: 3rem;
+animation: ${scaleIn} 0.8s ease-out forwards;
+margin-top: 3rem;
 `;

--- a/client/src/sidepanel/pages/Home.tsx
+++ b/client/src/sidepanel/pages/Home.tsx
@@ -2,30 +2,76 @@ import * as S from './Home.styles';
 import { useNavigate } from 'react-router-dom';
 import logo from '../../../public/icons/logo.png';
 import CommonButton from '../../components/CommonButton';
+import { useState, useEffect } from 'react';
+
+const TEXT_SEGMENTS = [
+  { text: "Let your ", highlight: false },
+  { text: "gaze", highlight: "gaze" },
+  { text: " lead the way.\nWe'll follow your ", highlight: false },
+  { text: "voice", highlight: "voice" },
+  { text: ".", highlight: false },
+];
 
 export default function Home() {
   const navigate = useNavigate();
+  const [typed, setTyped] = useState<string[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [charIndex, setCharIndex] = useState(0);
+  const [done, setDone] = useState(false);
+
+  useEffect(() => {
+    if (currentIndex >= TEXT_SEGMENTS.length) {
+      setDone(true);
+      return;
+    }
+
+    const segment = TEXT_SEGMENTS[currentIndex];
+    const fullText = segment.text;
+
+    if (charIndex < fullText.length) {
+      const timeout = setTimeout(() => {
+        const updated = [...typed];
+        updated[currentIndex] = (updated[currentIndex] || "") + fullText[charIndex];
+        setTyped(updated);
+        setCharIndex((prev) => prev + 1);
+      }, 100);
+      return () => clearTimeout(timeout);
+    } else {
+      setCurrentIndex((prev) => prev + 1);
+      setCharIndex(0);
+    }
+  }, [charIndex, currentIndex]);
 
   return (
     <S.Container>
       <S.LogoWrapper>
-        <img src={logo} alt="Mind Cursor Logo" style={{ width: '200px', height: 'auto' }} />
+        <img src={logo} alt="Mind Cursor Logo" style={{ width: '200px' }} />
       </S.LogoWrapper>
+
       <S.TextBox>
-        <S.Text>
-          Let your <S.Gaze>gaze</S.Gaze> lead the way.
-        </S.Text>
-        <S.Text>
-          We’ll follow your <S.Voice>voice</S.Voice>.
-        </S.Text>
+        <S.TypingText>
+          {typed.map((str, i) => {
+            const seg = TEXT_SEGMENTS[i];
+            if (seg.highlight === "gaze") {
+              return <S.Gaze key={i}>{str}</S.Gaze>;
+            }
+            if (seg.highlight === "voice") {
+              return <S.Voice key={i}>{str}</S.Voice>;
+            }
+            return <span key={i}>{str}</span>;
+          })}
+        </S.TypingText>
       </S.TextBox>
-      <S.ButtonWrapper>
-        <CommonButton
-          text="Start"
-          onClick={() => navigate('/choice')}
-          color="linear-gradient(to right, #B020D3, #0970E7)"
-        />
-      </S.ButtonWrapper>
+
+      {done && (
+        <S.ButtonWrapper>
+          <CommonButton
+            text="Start"
+            onClick={() => navigate('/choice')}
+            color="linear-gradient(to right, #B020D3, #0970E7)"
+          />
+        </S.ButtonWrapper>
+      )}
     </S.Container>
   );
 }

--- a/client/src/store/useUIStore.ts
+++ b/client/src/store/useUIStore.ts
@@ -1,19 +1,19 @@
-import { create } from "zustand";
+import { create } from 'zustand';
 
-type UIState = {
+interface UIState {
   isGazeActive: boolean;
   isVoiceActive: boolean;
   isHelpActive: boolean;
-  setGazeActive: (value: boolean) => void;
-  setVoiceActive: (value: boolean) => void;
-  setHelpActive: (value: boolean) => void;
-};
+  toggleGaze: () => void;
+  toggleVoice: () => void;
+  toggleHelp: () => void;
+}
 
 export const useUIStore = create<UIState>((set) => ({
   isGazeActive: false,
   isVoiceActive: false,
   isHelpActive: false,
-  setGazeActive: (value) => set({ isGazeActive: value }),
-  setVoiceActive: (value) => set({ isVoiceActive: value }),
-  setHelpActive: (value) => set({ isHelpActive: value }),
+  toggleGaze: () => set((state) => ({ isGazeActive: !state.isGazeActive })),
+  toggleVoice: () => set((state) => ({ isVoiceActive: !state.isVoiceActive })),
+  toggleHelp: () => set((state) => ({ isHelpActive: !state.isHelpActive })),
 }));


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🛰️ 관련 이슈
> #14 

## 🧑‍💻 작업 내용
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- 홈 화면 구현 완료
로고, 타이핑 애니메이션 효과 적용
'Start' 버튼 클릭 시 /choice 페이지로 이동

- 커스터마이징 선택 화면(choice) 1차 레이아웃 구현
기본 안내 문구 및 버튼 구성
버튼 스타일은 공통 버튼 컴포넌트(CommonButton) 사용

- 공통 아이콘 UI 개선
Gaze / Voice / Help 아이콘 클릭 시 상태 토글 기능 추가
Zustand 기반 전역 상태 연동 완료
아이콘은 전체 화면에서 항상 최상단에 고정되도록 설정

## 🗯️ PR 포인트
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 홈화면 레이아웃 구현 시작하고 브랜치를 안바꿔서... 7번 브랜치에 일부 들어가 있습니다... 이어서 14번 브랜치로 작업했습니다!

## 🚀 알게된 점
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->
- 

## 📖 참고 자료 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- 

## 📸 스크린샷 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->
![image](https://github.com/user-attachments/assets/035fcd2e-895b-455e-b160-2602049749c5)
![image](https://github.com/user-attachments/assets/c02b721b-d460-4365-ab03-39bad9991244)
